### PR TITLE
Added file exist check to DefinitionsReader:getDOM

### DIFF
--- a/src/DefinitionsReader.php
+++ b/src/DefinitionsReader.php
@@ -506,10 +506,7 @@ class DefinitionsReader
     {
         $xml = new DOMDocument('1.0', 'UTF-8');
         if (!$xml->load($file, LIBXML_NONET)) {
-            print_r(libxml_get_errors());
-            die();
             throw new IOException("Can't load the file $file");
-
         }
         return $xml;
     }


### PR DESCRIPTION
**version(s) affected**: v0.3.4

**Description**  
If provide not existing wsdl document to GoetasWebservices\XML\WSDLReader\DefinitionsReader:readFile()

Empty Array is printed out
```
Array (
)
```
When you use soap-client with lots of wsdl files in config it's quite hard to understand what is wrong and find the typo in configuration

```yaml
soap_client:
  metadata:
     not-existing.wsdl: ~ 
```


**How to reproduce**  
Use https://github.com/yuriy-yakubskiy/wsdl-reader-file-does-not-exist-error-reproducer

