### PR TITLE
symfony event dispatcher >= 4.3

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,12 +2,12 @@ language: php
 sudo: false
 
 php:
-  - 7.1
   - 7.2
+  - 7.3
 
 matrix:
   include:
-    - php: 7.1
+    - php: 7.2
       env: COMPOSER_FLAGS='--prefer-lowest --prefer-stable'
 
 cache:
@@ -16,9 +16,9 @@ cache:
     - $HOME/.composer/cache
 
 before_script:
-  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then echo "xdebug.max_nesting_level=1000" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
-  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]]; then PHPUNIT_FLAGS="--coverage-clover=coverage.clover"; else PHPUNIT_FLAGS=""; fi
-  - if [[ $TRAVIS_PHP_VERSION != '7.1' ]]; then phpenv config-rm xdebug.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then echo "xdebug.max_nesting_level=1000" >> ~/.phpenv/versions/$(phpenv version-name)/etc/php.ini; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]]; then PHPUNIT_FLAGS="--coverage-clover=coverage.clover"; else PHPUNIT_FLAGS=""; fi
+  - if [[ $TRAVIS_PHP_VERSION != '7.2' ]]; then phpenv config-rm xdebug.ini; fi
   - travis_retry composer self-update
   - travis_retry composer update $COMPOSER_FLAGS
 
@@ -26,5 +26,5 @@ script: vendor/bin/phpunit $PHPUNIT_FLAGS
 
 after_script:
   - wget https://scrutinizer-ci.com/ocular.phar
-  - if [[ $TRAVIS_PHP_VERSION = '7.1' ]] ; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
+  - if [[ $TRAVIS_PHP_VERSION = '7.2' ]] ; then php ocular.phar code-coverage:upload --format=php-clover coverage.clover; fi
 

--- a/composer.json
+++ b/composer.json
@@ -8,13 +8,12 @@
         "email": "goetas@gmail.com"
     }],
     "require": {
-        "php": "^7.1",
+        "php": "^7.2",
         "goetas-webservices/xsd-reader": "^0.3@dev",
-        "symfony/event-dispatcher": "^2.4||^3.0||^4.0"
+        "symfony/event-dispatcher": "^4.3||^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^4.8|^5.0",
-        "jmikola/wildcard-event-dispatcher": "~1.0"
+        "phpunit/phpunit": "^8.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -9,11 +9,12 @@
     }],
     "require": {
         "php": "^7.2",
-        "goetas-webservices/xsd-reader": "^0.3@dev",
-        "symfony/event-dispatcher": "^4.3||^5.0"
+        "goetas-webservices/xsd-reader": "^0.3",
+        "symfony/event-dispatcher-contracts": "^1.1||^2.0",
+        "symfony/event-dispatcher": "^3.4||^4.3||^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit": "^8.0"
+        "phpunit/phpunit": "^8.0|^9.0"
     },
     "autoload": {
         "psr-4": {

--- a/src/DefinitionsReader.php
+++ b/src/DefinitionsReader.php
@@ -35,6 +35,7 @@ use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\XML\XSDReader\Utils\UrlUtils;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
+use Symfony\Component\EventDispatcher\LegacyEventDispatcherProxy;
 
 class DefinitionsReader
 {
@@ -60,7 +61,7 @@ class DefinitionsReader
     public function __construct(SchemaReader $reader = null, EventDispatcherInterface $dispatcher = null)
     {
         $this->reader = $reader ?: new SchemaReader();
-        $this->dispatcher = $dispatcher ?: new EventDispatcher();
+        $this->dispatcher = LegacyEventDispatcherProxy::decorate($dispatcher ?: new EventDispatcher());
     }
 
     /**

--- a/src/DefinitionsReader.php
+++ b/src/DefinitionsReader.php
@@ -33,7 +33,6 @@ use GoetasWebservices\XML\XSDReader\Exception\IOException;
 use GoetasWebservices\XML\XSDReader\Schema\Schema;
 use GoetasWebservices\XML\XSDReader\SchemaReader;
 use GoetasWebservices\XML\XSDReader\Utils\UrlUtils;
-use Symfony\Component\EventDispatcher\Event;
 use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Component\EventDispatcher\EventDispatcherInterface;
 
@@ -48,13 +47,13 @@ class DefinitionsReader
 
     /**
      *
-     * @var \GoetasWebservices\XML\XSDReader\SchemaReader
+     * @var SchemaReader
      */
     private $reader;
 
     /**
      *
-     * @var \Symfony\Component\EventDispatcher\EventDispatcherInterface
+     * @var EventDispatcherInterface
      */
     private $dispatcher;
 
@@ -90,11 +89,6 @@ class DefinitionsReader
             $childs[] = $childNode;
         }
         return $childs;
-    }
-
-    private function dispatch($eventName, Event $event)
-    {
-        ;
     }
 
     /**
@@ -141,13 +135,13 @@ class DefinitionsReader
         ksort($functions);
         return array(
             function () use ($functions, $definitions, $node) {
-                $this->dispatcher->dispatch('definitions_start', new DefinitionsEvent($definitions, $node));
+                $this->dispatcher->dispatch(new DefinitionsEvent($definitions, $node), 'definitions_start');
                 foreach ($functions as $subFunctions) {
                     foreach ($subFunctions as $function) {
                         call_user_func($function);
                     }
                 }
-                $this->dispatcher->dispatch('definitions_end', new DefinitionsEvent($definitions, $node));
+                $this->dispatcher->dispatch(new DefinitionsEvent($definitions, $node), 'definitions_end');
             }
         );
     }
@@ -176,7 +170,7 @@ class DefinitionsReader
             list ($name, $ns) = self::splitParts($node, $node->getAttribute("type"));
             $binding->setType($definitions->findPortType($name, $ns));
 
-            $this->dispatcher->dispatch('binding', new BindingEvent($binding, $node));
+            $this->dispatcher->dispatch(new BindingEvent($binding, $node), 'binding');
             foreach ($functions as $function) {
                 call_user_func($function);
             }
@@ -204,7 +198,7 @@ class DefinitionsReader
             }
         }
         return function () use ($functions, $bindingOperation, $node) {
-            $this->dispatcher->dispatch('binding.operation', new BindingOperationEvent($bindingOperation, $node));
+            $this->dispatcher->dispatch(new BindingOperationEvent($bindingOperation, $node), 'binding.operation');
             foreach ($functions as $function) {
                 call_user_func($function);
             }
@@ -222,7 +216,7 @@ class DefinitionsReader
         }
 
         return function () use ($message, $node, $isInput) {
-            $this->dispatcher->dispatch('binding.operation.message', new BindingOperationMessageEvent($message, $node, $isInput ? 'input' : 'output'));
+            $this->dispatcher->dispatch(new BindingOperationMessageEvent($message, $node, $isInput ? 'input' : 'output'), 'binding.operation.message');
         };
     }
 
@@ -233,7 +227,7 @@ class DefinitionsReader
         $bindingOperation->addFault($fault);
 
         return function () use ($fault, $node) {
-            $this->dispatcher->dispatch('binding.operation.fault', new BindingOperationFaultEvent($fault, $node));
+            $this->dispatcher->dispatch(new BindingOperationFaultEvent($fault, $node), 'binding.operation.fault');
         };
     }
 
@@ -252,7 +246,7 @@ class DefinitionsReader
             }
         }
         return function () use ($functions, $service, $node) {
-            $this->dispatcher->dispatch('service', new ServiceEvent($service, $node));
+            $this->dispatcher->dispatch(new ServiceEvent($service, $node), 'service');
             foreach ($functions as $function) {
                 call_user_func($function);
             }
@@ -275,7 +269,7 @@ class DefinitionsReader
         }
 
         return function () use ($functions, $message, $node) {
-            $this->dispatcher->dispatch('message', new MessageEvent($message, $node));
+            $this->dispatcher->dispatch(new MessageEvent($message, $node), 'message');
             foreach ($functions as $function) {
                 call_user_func($function);
             }
@@ -291,7 +285,7 @@ class DefinitionsReader
             list ($name, $ns) = self::splitParts($node, $node->getAttribute("binding"));
             $port->setBinding($service->getDefinition()
                 ->findBinding($name, $ns));
-            $this->dispatcher->dispatch('service.port', new PortEvent($port, $node));
+            $this->dispatcher->dispatch(new PortEvent($port, $node), 'service.port');
         };
     }
 
@@ -310,7 +304,7 @@ class DefinitionsReader
             }
         }
         return function () use ($functions, $port, $node) {
-            $this->dispatcher->dispatch('portType', new PortTypeEvent($port, $node));
+            $this->dispatcher->dispatch(new PortTypeEvent($port, $node), 'portType');
             foreach ($functions as $function) {
                 call_user_func($function);
             }
@@ -339,7 +333,7 @@ class DefinitionsReader
             }
         }
         return function () use ($functions, $operation, $node) {
-            $this->dispatcher->dispatch('portType.operation', new OperationEvent($operation, $node));
+            $this->dispatcher->dispatch(new OperationEvent($operation, $node), 'portType.operation');
             foreach ($functions as $function) {
                 call_user_func($function);
             }
@@ -361,7 +355,7 @@ class DefinitionsReader
             list ($name, $ns) = self::splitParts($node, $node->getAttribute("message"));
             $param->setMessage($operation->getDefinition()
                 ->findMessage($name, $ns));
-            $this->dispatcher->dispatch('portType.operation.param', new ParamEvent($param, $node));
+            $this->dispatcher->dispatch(new ParamEvent($param, $node), 'portType.operation.param');
         };
     }
 
@@ -375,7 +369,7 @@ class DefinitionsReader
             list ($name, $ns) = self::splitParts($node, $node->getAttribute("message"));
             $fault->setMessage($operation->getDefinition()->findMessage($name, $ns));
 
-            $this->dispatcher->dispatch('portType.operation.fault', new FaultEvent($fault, $node));
+            $this->dispatcher->dispatch(new FaultEvent($fault, $node), 'portType.operation.fault');
         };
     }
 
@@ -397,7 +391,7 @@ class DefinitionsReader
                     ->getSchema()
                     ->findType($name, $ns));
             }
-            $this->dispatcher->dispatch('message.part', new MessagePartEvent($part, $node));
+            $this->dispatcher->dispatch(new MessagePartEvent($part, $node), 'message.part');
         };
     }
 
@@ -452,7 +446,7 @@ class DefinitionsReader
 
     /**
      *
-     * @return \oetas\XML\WSDLReader\Wsdl\Definitions
+     * @return Definitions
      */
     public function readNode(\DOMElement $node, $file = 'wsdl.xsd')
     {
@@ -473,7 +467,7 @@ class DefinitionsReader
 
     /**
      *
-     * @return \oetas\XML\WSDLReader\Wsdl\Definitions
+     * @return Definitions
      */
     public function readString($content, $file = 'wsdl.xsd')
     {

--- a/src/Events/Binding/FaultEvent.php
+++ b/src/Events/Binding/FaultEvent.php
@@ -3,7 +3,6 @@ namespace GoetasWebservices\XML\WSDLReader\Events\Binding;
 
 use GoetasWebservices\XML\WSDLReader\Events\WsdlEvent;
 use GoetasWebservices\XML\WSDLReader\Wsdl\Binding\OperationFault;
-use Symfony\Component\EventDispatcher\Event;
 
 class FaultEvent extends WsdlEvent
 {

--- a/src/Events/Binding/MessageEvent.php
+++ b/src/Events/Binding/MessageEvent.php
@@ -3,7 +3,6 @@ namespace GoetasWebservices\XML\WSDLReader\Events\Binding;
 
 use GoetasWebservices\XML\WSDLReader\Events\WsdlEvent;
 use GoetasWebservices\XML\WSDLReader\Wsdl\Binding\OperationMessage;
-use Symfony\Component\EventDispatcher\Event;
 
 class MessageEvent extends WsdlEvent
 {

--- a/src/Events/Binding/OperationEvent.php
+++ b/src/Events/Binding/OperationEvent.php
@@ -3,7 +3,6 @@ namespace GoetasWebservices\XML\WSDLReader\Events\Binding;
 
 use GoetasWebservices\XML\WSDLReader\Events\WsdlEvent;
 use GoetasWebservices\XML\WSDLReader\Wsdl\Binding\Operation;
-use Symfony\Component\EventDispatcher\Event;
 
 class OperationEvent extends WsdlEvent
 {

--- a/src/Events/BindingEvent.php
+++ b/src/Events/BindingEvent.php
@@ -2,7 +2,6 @@
 namespace GoetasWebservices\XML\WSDLReader\Events;
 
 use GoetasWebservices\XML\WSDLReader\Wsdl\Binding;
-use Symfony\Component\EventDispatcher\Event;
 
 class BindingEvent extends WsdlEvent
 {

--- a/src/Events/DefinitionsEvent.php
+++ b/src/Events/DefinitionsEvent.php
@@ -2,7 +2,6 @@
 namespace GoetasWebservices\XML\WSDLReader\Events;
 
 use GoetasWebservices\XML\WSDLReader\Wsdl\Definitions;
-use Symfony\Component\EventDispatcher\Event;
 
 class DefinitionsEvent extends WsdlEvent
 {

--- a/src/Events/Message/PartEvent.php
+++ b/src/Events/Message/PartEvent.php
@@ -3,7 +3,6 @@ namespace GoetasWebservices\XML\WSDLReader\Events\Message;
 
 use GoetasWebservices\XML\WSDLReader\Events\WsdlEvent;
 use GoetasWebservices\XML\WSDLReader\Wsdl\Message\Part;
-use Symfony\Component\EventDispatcher\Event;
 
 class PartEvent extends WsdlEvent
 {

--- a/src/Events/MessageEvent.php
+++ b/src/Events/MessageEvent.php
@@ -2,7 +2,6 @@
 namespace GoetasWebservices\XML\WSDLReader\Events;
 
 use GoetasWebservices\XML\WSDLReader\Wsdl\Message;
-use Symfony\Component\EventDispatcher\Event;
 
 class MessageEvent extends WsdlEvent
 {

--- a/src/Events/PortType/FaultEvent.php
+++ b/src/Events/PortType/FaultEvent.php
@@ -3,7 +3,6 @@ namespace GoetasWebservices\XML\WSDLReader\Events\PortType;
 
 use GoetasWebservices\XML\WSDLReader\Events\WsdlEvent;
 use GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Fault;
-use Symfony\Component\EventDispatcher\Event;
 
 class FaultEvent extends WsdlEvent
 {

--- a/src/Events/PortType/OperationEvent.php
+++ b/src/Events/PortType/OperationEvent.php
@@ -3,7 +3,6 @@ namespace GoetasWebservices\XML\WSDLReader\Events\PortType;
 
 use GoetasWebservices\XML\WSDLReader\Events\WsdlEvent;
 use GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Operation;
-use Symfony\Component\EventDispatcher\Event;
 
 class OperationEvent extends WsdlEvent
 {

--- a/src/Events/PortType/ParamEvent.php
+++ b/src/Events/PortType/ParamEvent.php
@@ -3,7 +3,6 @@ namespace GoetasWebservices\XML\WSDLReader\Events\PortType;
 
 use GoetasWebservices\XML\WSDLReader\Events\WsdlEvent;
 use GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Param;
-use Symfony\Component\EventDispatcher\Event;
 
 class ParamEvent extends WsdlEvent
 {

--- a/src/Events/PortTypeEvent.php
+++ b/src/Events/PortTypeEvent.php
@@ -2,7 +2,6 @@
 namespace GoetasWebservices\XML\WSDLReader\Events;
 
 use GoetasWebservices\XML\WSDLReader\Wsdl\PortType;
-use Symfony\Component\EventDispatcher\Event;
 
 class PortTypeEvent extends WsdlEvent
 {

--- a/src/Events/ServiceEvent.php
+++ b/src/Events/ServiceEvent.php
@@ -2,7 +2,6 @@
 namespace GoetasWebservices\XML\WSDLReader\Events;
 
 use GoetasWebservices\XML\WSDLReader\Wsdl\Service;
-use Symfony\Component\EventDispatcher\Event;
 
 class ServiceEvent extends WsdlEvent
 {

--- a/src/Events/WsdlEvent.php
+++ b/src/Events/WsdlEvent.php
@@ -1,7 +1,7 @@
 <?php
 namespace GoetasWebservices\XML\WSDLReader\Events;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 abstract class WsdlEvent extends Event
 {

--- a/src/Wsdl/Binding.php
+++ b/src/Wsdl/Binding.php
@@ -1,6 +1,8 @@
 <?php
 namespace GoetasWebservices\XML\WSDLReader\Wsdl;
 
+use GoetasWebservices\XML\WSDLReader\Wsdl\Binding\Operation;
+
 /**
  * XSD Type: tBinding
  */
@@ -13,7 +15,7 @@ class Binding extends ExtensibleDocumented
     protected $name;
 
     /**
-     * @var \GoetasWebservices\XML\WSDLReader\Wsdl\PortType
+     * @var PortType
      */
     protected $type;
 
@@ -49,7 +51,7 @@ class Binding extends ExtensibleDocumented
 
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType
+     * @return PortType
      */
     public function getType()
     {
@@ -58,7 +60,7 @@ class Binding extends ExtensibleDocumented
 
     /**
      * @param $type string
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType
+     * @return PortType
      */
     public function setType(PortType $type)
     {
@@ -68,16 +70,17 @@ class Binding extends ExtensibleDocumented
 
 
     /**
-     * @param $operation \GoetasWebservices\XML\WSDLReader\Wsdl\BindingOperation
+     * @param Operation $operation
+     * @return Binding
      */
-    public function addOperation(\GoetasWebservices\XML\WSDLReader\Wsdl\Binding\Operation $operation)
+    public function addOperation(Operation $operation)
     {
         $this->operation[$operation->getName()] = $operation;
         return $this;
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Binding\Operation
+     * @return Operation
      */
     public function getOperation($name)
     {
@@ -85,7 +88,7 @@ class Binding extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Binding\Operation[]
+     * @return Operation[]
      */
     public function getOperations()
     {

--- a/src/Wsdl/Definitions.php
+++ b/src/Wsdl/Definitions.php
@@ -27,7 +27,7 @@ class Definitions extends ExtensibleDocumented
     protected $import = array();
 
     /**
-     * @var \GoetasWebservices\XML\XSDReader\Schema\Schema
+     * @var Schema
      */
     protected $schema;
 
@@ -93,7 +93,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @param $import \GoetasWebservices\XML\WSDLReader\Wsdl\Definitions
+     * @param $import Definitions
      */
     public function addImport(Definitions $import)
     {
@@ -103,7 +103,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Definitions[]
+     * @return Definitions[]
      */
     public function getImports()
     {
@@ -111,7 +111,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\XSDReader\Schema\Schema
+     * @return Schema
      */
     public function getSchema()
     {
@@ -121,7 +121,7 @@ class Definitions extends ExtensibleDocumented
 
     /**
      * @param Schema $schema
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Definitions
+     * @return Definitions
      */
     public function setSchema(Schema $schema)
     {
@@ -131,16 +131,16 @@ class Definitions extends ExtensibleDocumented
 
 
     /**
-     * @param $message \GoetasWebservices\XML\WSDLReader\Wsdl\Message
+     * @param $message Message
      */
-    public function addMessage(\GoetasWebservices\XML\WSDLReader\Wsdl\Message $message)
+    public function addMessage(Message $message)
     {
         $this->message[$message->getName()] = $message;
         return $this;
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Message
+     * @return Message
      */
     public function getMessage($name)
     {
@@ -150,7 +150,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Message[]
+     * @return Message[]
      */
     public function getMessages()
     {
@@ -158,16 +158,16 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @param $portType \GoetasWebservices\XML\WSDLReader\Wsdl\PortType
+     * @param $portType PortType
      */
-    public function addPortType(\GoetasWebservices\XML\WSDLReader\Wsdl\PortType $portType)
+    public function addPortType(PortType $portType)
     {
         $this->portType[$portType->getName()] = $portType;
         return $this;
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType
+     * @return PortType
      */
     public function getPortType($name)
     {
@@ -175,7 +175,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType[]
+     * @return PortType[]
      */
     public function getPortTypes()
     {
@@ -183,7 +183,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType[]
+     * @return PortType[]
      */
     public function getAllPortTypes()
     {
@@ -195,16 +195,16 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @param $binding \GoetasWebservices\XML\WSDLReader\Wsdl\Binding
+     * @param $binding Binding
      */
-    public function addBinding(\GoetasWebservices\XML\WSDLReader\Wsdl\Binding $binding)
+    public function addBinding(Binding $binding)
     {
         $this->binding[$binding->getName()] = $binding;
         return $this;
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Binding
+     * @return Binding
      */
     public function getBinding($name)
     {
@@ -214,7 +214,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Binding[]
+     * @return Binding[]
      */
     public function getBindings()
     {
@@ -222,16 +222,16 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @param $service \GoetasWebservices\XML\WSDLReader\Wsdl\Service
+     * @param $service Service
      */
-    public function addService(\GoetasWebservices\XML\WSDLReader\Wsdl\Service $service)
+    public function addService(Service $service)
     {
         $this->service[$service->getName()] = $service;
         return $this;
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Service
+     * @return Service
      */
     public function getService($name)
     {
@@ -242,7 +242,7 @@ class Definitions extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Service[]
+     * @return Service[]
      */
     public function getServices()
     {
@@ -252,7 +252,7 @@ class Definitions extends ExtensibleDocumented
     /**
      * @param string $name
      * @param string $namespace
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Binding
+     * @return Binding
      */
     public function findBinding($name, $namespace = null)
     {
@@ -262,7 +262,7 @@ class Definitions extends ExtensibleDocumented
     /**
      * @param string $name
      * @param string $namespace
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType
+     * @return PortType
      */
     public function findPortType($name, $namespace = null)
     {
@@ -272,7 +272,7 @@ class Definitions extends ExtensibleDocumented
     /**
      * @param string $name
      * @param string $namespace
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Service
+     * @return Service
      */
     public function findService($name, $namespace = null)
     {
@@ -282,7 +282,7 @@ class Definitions extends ExtensibleDocumented
     /**
      * @param string $name
      * @param string $namespace
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Message
+     * @return Message
      */
     public function findMessage($name, $namespace = null)
     {

--- a/src/Wsdl/Message.php
+++ b/src/Wsdl/Message.php
@@ -1,5 +1,6 @@
 <?php
 namespace GoetasWebservices\XML\WSDLReader\Wsdl;
+
 use GoetasWebservices\XML\WSDLReader\Exception\PartNotFoundException;
 
 /**

--- a/src/Wsdl/PortType.php
+++ b/src/Wsdl/PortType.php
@@ -1,6 +1,8 @@
 <?php
 namespace GoetasWebservices\XML\WSDLReader\Wsdl;
+
 use GoetasWebservices\XML\WSDLReader\Exception\OperationNotFoundException;
+use GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Operation;
 
 /**
  * XSD Type: tPortType
@@ -44,16 +46,16 @@ class PortType extends ExtensibleAttributesDocumented
 
 
     /**
-     * @param $operation \GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Operation
+     * @param $operation Operation
      */
-    public function addOperation(\GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Operation $operation)
+    public function addOperation(Operation $operation)
     {
         $this->operation[$operation->getName()] = $operation;
         return $this;
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Operation
+     * @return Operation
      */
     public function getOperation($name)
     {
@@ -64,7 +66,7 @@ class PortType extends ExtensibleAttributesDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\PortType\Operation[]
+     * @return Operation[]
      */
     public function getOperations()
     {

--- a/src/Wsdl/Service.php
+++ b/src/Wsdl/Service.php
@@ -1,6 +1,8 @@
 <?php
 namespace GoetasWebservices\XML\WSDLReader\Wsdl;
+
 use GoetasWebservices\XML\WSDLReader\Exception\PortNotFoundException;
+use GoetasWebservices\XML\WSDLReader\Wsdl\Service\Port;
 
 /**
  * XSD Type: tService
@@ -45,9 +47,9 @@ class Service extends ExtensibleDocumented
 
 
     /**
-     * @param $port \GoetasWebservices\XML\WSDLReader\Wsdl\Service\Port
+     * @param $port Port
      */
-    public function addPort(\GoetasWebservices\XML\WSDLReader\Wsdl\Service\Port $port)
+    public function addPort(Port $port)
     {
         $this->port[$port->getName()] = $port;
         return $this;
@@ -62,7 +64,7 @@ class Service extends ExtensibleDocumented
     }
 
     /**
-     * @return \GoetasWebservices\XML\WSDLReader\Wsdl\Service\Port[]
+     * @return Port[]
      */
     public function getPorts()
     {

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -3,6 +3,7 @@ namespace GoetasWebservices\XML\WSDLReader\Tests;
 
 use GoetasWebservices\XML\WSDLReader\DefinitionsReader;
 use GoetasWebservices\XML\WSDLReader\Wsdl\Definitions;
+use GoetasWebservices\XML\WSDLReader\Wsdl\TypeNotFoundException;
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementDef;
 use GoetasWebservices\XML\XSDReader\Schema\Type\ComplexType;
 use PHPUnit\Framework\TestCase;
@@ -74,11 +75,9 @@ class BaseTest extends TestCase
         $this->assertNotNull($definitions->findService('StockQuote', 'http://www.example.com'));
     }
 
-    /**
-     * @expectedException \Exception
-     */
     public function testTypeNotFound()
     {
+        $this->expectException(TypeNotFoundException::class);
         $definitions = $this->reader->readFile(__DIR__ . '/resources/base-wsdl-import.wsdl');
         $this->assertNotNull($definitions->findBinding('StockQuoteSoap2', 'http://www.example.com'));
     }

--- a/tests/BaseTest.php
+++ b/tests/BaseTest.php
@@ -5,8 +5,9 @@ use GoetasWebservices\XML\WSDLReader\DefinitionsReader;
 use GoetasWebservices\XML\WSDLReader\Wsdl\Definitions;
 use GoetasWebservices\XML\XSDReader\Schema\Element\ElementDef;
 use GoetasWebservices\XML\XSDReader\Schema\Type\ComplexType;
+use PHPUnit\Framework\TestCase;
 
-class BaseTest extends \PHPUnit_Framework_TestCase
+class BaseTest extends TestCase
 {
 
     /**
@@ -15,7 +16,7 @@ class BaseTest extends \PHPUnit_Framework_TestCase
      */
     protected $reader;
 
-    public function setUp()
+    public function setUp(): void
     {
         $this->reader = new DefinitionsReader();
     }

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -2,10 +2,10 @@
 namespace GoetasWebservices\XML\WSDLReader\Tests;
 
 use GoetasWebservices\XML\WSDLReader\DefinitionsReader;
-use Jmikola\WildcardEventDispatcher\WildcardEventDispatcher;
-use Symfony\Component\EventDispatcher\Event;
+use PHPUnit\Framework\TestCase;
+use Symfony\Contracts\EventDispatcher\Event;
 
-class EventsTest extends \PHPUnit_Framework_TestCase
+class EventsTest extends TestCase
 {
 
     /**
@@ -16,13 +16,14 @@ class EventsTest extends \PHPUnit_Framework_TestCase
 
     /**
      *
-     * @var \Jmikola\WildcardEventDispatcher\WildcardEventDispatcher
+     * var \Jmikola\WildcardEventDispatcher\WildcardEventDispatcher
      */
     protected $dispatcher;
 
-    public function setUp()
+    public function setUp(): void
     {
-        $this->dispatcher = new WildcardEventDispatcher();
+        $this->markTestSkipped('must be revisited.');
+        //$this->dispatcher = new WildcardEventDispatcher();
         $this->reader = new DefinitionsReader(null, $this->dispatcher);
     }
 
@@ -74,7 +75,7 @@ class EventsTest extends \PHPUnit_Framework_TestCase
 
         foreach ($expected as $index => $expectedData) {
             list($event, $name) = $events[$index];
-            $this->assertInstanceOf('Symfony\Component\EventDispatcher\Event', $event);
+            $this->assertInstanceOf('Symfony\Contracts\EventDispatcher\Event', $event);
             $this->assertInstanceOf('GoetasWebservices\XML\WSDLReader\Events\WsdlEvent', $event);
             $this->assertInstanceOf($expectedData[1], $event, "Event name '$expectedData[0]'");
             $this->assertEquals($expectedData[0], $name);

--- a/tests/EventsTest.php
+++ b/tests/EventsTest.php
@@ -3,6 +3,7 @@ namespace GoetasWebservices\XML\WSDLReader\Tests;
 
 use GoetasWebservices\XML\WSDLReader\DefinitionsReader;
 use PHPUnit\Framework\TestCase;
+use Symfony\Component\EventDispatcher\EventDispatcher;
 use Symfony\Contracts\EventDispatcher\Event;
 
 class EventsTest extends TestCase
@@ -22,17 +23,31 @@ class EventsTest extends TestCase
 
     public function setUp(): void
     {
-        $this->markTestSkipped('must be revisited.');
-        //$this->dispatcher = new WildcardEventDispatcher();
+        //TODO use WildcardEventDispatcher again
+        $this->dispatcher = new EventDispatcher();
         $this->reader = new DefinitionsReader(null, $this->dispatcher);
     }
 
     public function testReadFile()
     {
         $events = array();
-        $this->dispatcher->addListener("#", function (Event $e, $name) use (&$events) {
+        $closure = function (Event $e, $name) use (&$events) {
             $events[] = [$e, $name];
-        });
+        };
+        $this->dispatcher->addListener("definitions_start", $closure);
+        $this->dispatcher->addListener("service", $closure);
+        $this->dispatcher->addListener("service.port", $closure);
+        $this->dispatcher->addListener("message", $closure);
+        $this->dispatcher->addListener("message.part", $closure);
+        $this->dispatcher->addListener("portType", $closure);
+        $this->dispatcher->addListener("portType.operation", $closure);
+        $this->dispatcher->addListener("portType.operation.param", $closure);
+        $this->dispatcher->addListener("portType.operation.fault", $closure);
+        $this->dispatcher->addListener("binding", $closure);
+        $this->dispatcher->addListener("binding.operation", $closure);
+        $this->dispatcher->addListener("binding.operation.message", $closure);
+        $this->dispatcher->addListener("binding.operation.fault", $closure);
+        $this->dispatcher->addListener("definitions_end", $closure);
         $this->reader->readFile(__DIR__ . '/resources/base-wsdl-events.wsdl');
 
         $expected = [];


### PR DESCRIPTION
As of [Symfony 4.3: Simpler event dispatching](https://symfony.com/blog/new-in-symfony-4-3-simpler-event-dispatching)

Adds support for symfony 4.3 and newer, since older versions are unsupported now it should be published with a new major version like v1.0.0

[jmikola/wildcard-event-dispatcher](https://github.com/jmikola/WildcardEventDispatcher) currently does not support the new event dispatcher, so for now removed and test skipped, PR created.