### PR TITLE
Consenti Symfony 6/7 (symfony/event-dispatcher)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,8 @@
     "require": {
         "php": "^7.1|^8.0",
         "goetas-webservices/xsd-reader": "^0.3",
-        "symfony/event-dispatcher-contracts": "^1.1|^2.0",
-        "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0",
+        "symfony/event-dispatcher-contracts": "^1.1|^2.0|^3.0",
+        "symfony/event-dispatcher": "^2.4|^3.0|^4.0|^5.0|^6.0|^7.0",
         "ext-dom": "*"
     },
     "require-dev": {


### PR DESCRIPTION
Allarga il vincolo di `symfony/event-dispatcher` e `symfony/event-dispatcher-contracts` per includere Symfony 6 e 7, cosi il pacchetto puo essere usato in progetti gia aggiornati. Nessuna modifica di codice.

Testato con la suite phpunit esistente (7 test, invariati) e con un progetto reale che usa questo pacchetto per leggere WSDL contro un servizio SOAP di terzi a runtime.